### PR TITLE
fix: remove null check operator and perform appropriate null check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2
+
+- Remove null check operator for disabledPickers and perform appropriate null check
+
 ## 0.6.1
 
 - Gave disabledPickers a default value to stop null errors.

--- a/lib/src/media_picker.dart
+++ b/lib/src/media_picker.dart
@@ -145,9 +145,7 @@ class _MediaPickerState extends State<MediaPicker> {
         ),
     ];
 
-    if (widget.mediaPickerInputs != null) {
-      inputs = widget.mediaPickerInputs!;
-    }
+    inputs = widget.mediaPickerInputs ?? inputs;
 
     var theme = Theme.of(context);
     return Wrap(
@@ -166,7 +164,7 @@ class _MediaPickerState extends State<MediaPicker> {
           ),
         ] else ...[
           for (final input in inputs) ...[
-            if (widget.disabledPickers!.contains(input.label) == true) ...[
+            if (isInputDisabled(input)) ...[
               IgnorePointer(
                 child: gestureDetectorWidget(input, theme),
               )
@@ -177,6 +175,10 @@ class _MediaPickerState extends State<MediaPicker> {
         ]
       ],
     );
+  }
+
+  bool isInputDisabled(MediaPickerInput input) {
+    return widget.disabledPickers?.contains(input.label) ?? false;
   }
 
   Future<void> onPressedMediaType(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_media_picker
 description: A new Flutter package project.
-version: 0.6.1
+version: 0.6.2
 homepage: https://github.com/Iconica-Development/flutter_media_picker
 publish_to: "none"
 


### PR DESCRIPTION
Now it is no longer possible to break the widget by providing a null value to the disabledPickers property. Making the property to a non-nullable list would remove more complexity, but introduces breaking changes.