### PR TITLE
chore(deps): loosen dep on intl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.4
+
+- Loosened the dependency on intl to be more compatible with several Flutter versions
+
 ## 0.6.2
 
 - Remove null check operator for disabledPickers and perform appropriate null check

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   cross_file:
     dependency: transitive
     description:
@@ -114,20 +114,20 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "6.1.0"
-      resolved-ref: b104a3344cdd0bddcd2e16566ddbb488795d77f0
+      ref: "6.3.2"
+      resolved-ref: a9d3a2c7514d988394795225c9d7b12478d6c91a
       url: "https://github.com/Iconica-Development/flutter_form_wizard.git"
     source: git
-    version: "6.1.0"
+    version: "6.3.2"
   flutter_input_library:
     dependency: transitive
     description:
       path: "."
-      ref: "2.1.0"
-      resolved-ref: dd7129a6b9725e6df1ea8f2a7db75eb36dbc1fa8
+      ref: "3.3.1"
+      resolved-ref: fbc64dcc232e298216a6fa64114b621314b5712a
       url: "https://github.com/Iconica-Development/flutter_input_library"
     source: git
-    version: "2.1.0"
+    version: "3.3.1"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -147,7 +147,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.6.2"
+    version: "0.6.3"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -258,10 +258,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.1"
+    version: "0.19.0"
   js:
     dependency: transitive
     description:
@@ -270,6 +270,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.7"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.4"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -290,26 +314,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -330,10 +354,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   path_provider:
     dependency: transitive
     description:
@@ -479,18 +503,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
@@ -519,10 +543,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -587,14 +611,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.16"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      name: vm_service
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "14.2.1"
   win32:
     dependency: transitive
     description:
@@ -612,5 +636,5 @@ packages:
     source: hosted
     version: "1.0.0"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
-  flutter: ">=3.3.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   flutter_form_wizard:
     git:
       url: https://github.com/Iconica-Development/flutter_form_wizard.git
-      ref: 6.1.0
+      ref: 6.3.2
   flutter_media_picker:
     path: ../
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,13 +18,13 @@ dependencies:
   video_player: ^2.6.0
   path_provider: ^2.0.13
   flutter_sound: ^9.2.13
-  intl: ^0.18.0
+  intl: ">=0.18.0 <1.0.0"
   permission_handler: ^10.2.0
   logger: ^1.3.0
   flutter_form_wizard:
     git:
       url: https://github.com/Iconica-Development/flutter_form_wizard.git
-      ref: 6.1.0
+      ref: 6.3.2
   mime: ^1.0.3
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_media_picker
 description: A new Flutter package project.
-version: 0.6.3
+version: 0.6.4
 homepage: https://github.com/Iconica-Development/flutter_media_picker
 publish_to: "none"
 


### PR DESCRIPTION
The latest Flutter requires intl 0.19.0 and now every app/package
depending on us fails to build with the latest Flutter because we were
explicitly requiring 0.18.0

Minor upgrades should be safe anyway, we only care for major versions
upgrade, so loosen the requirements a bit to support anything from
0.18.0 up to (but not including) 1.0.0